### PR TITLE
feat: upstream open-source tooling from internal build (Phase 3)

### DIFF
--- a/docker/Dockerfile.terrarium
+++ b/docker/Dockerfile.terrarium
@@ -704,7 +704,7 @@ ARG OC_VERSION=4.19.0
 RUN arch="${TARGETARCH:-$(echo "${TARGETPLATFORM:-linux/amd64}" | cut -d/ -f2)}" \
     && fetch -o /tmp/oc.tgz \
        "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux-${arch}-rhel9.tar.gz" \
-    && tar -C /usr/local/bin -xzf /tmp/oc.tgz \
+    && tar -C /usr/local/bin -xzf /tmp/oc.tgz oc \
     && rm -f /tmp/oc.tgz \
     && oc version --client
 
@@ -714,7 +714,7 @@ ARG OPENSTACK_CLIENT_VERSION=7.1.4
 RUN python -m venv ${OPENSTACK_VENV} \
     && ${OPENSTACK_VENV}/bin/pip install --no-cache-dir \
        python-openstackclient==${OPENSTACK_CLIENT_VERSION} \
-       python-barbicanclient \
+       python-barbicanclient==7.3.0 \
     && ln -s ${OPENSTACK_VENV}/bin/openstack /usr/local/bin/openstack \
     && openstack --version
 
@@ -730,17 +730,23 @@ RUN rm -rf ${HOME}/.npm ${HOME}/.npm-global \
     && chown 1001:0 ${HOME}/.npmrc
 ENV PATH="${HOME}/.npm-global/bin:${PATH}"
 
-# --- Persistent bash history -------------------------------------------------
-RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-    && mkdir -p /commandhistory \
-    && touch /commandhistory/.bash_history \
-    && chown -R 1001:0 /commandhistory \
-    && echo "$SNIPPET" >> "${HOME}/.bashrc"
-
 # --- Shell init (zoxide, starship, local bins) --------------------------------
 RUN echo 'eval "$(zoxide init bash)"' >> "${HOME}/.bashrc" \
     && echo 'eval "$(starship init bash)"' >> "${HOME}/.bashrc" \
     && echo 'export PATH="$HOME/.local/bin:$PATH"' >> "${HOME}/.bashrc"
+
+# --- Persistent bash history (after shell init to append to PROMPT_COMMAND) ---
+RUN mkdir -p /commandhistory \
+    && touch /commandhistory/.bash_history \
+    && chown -R 1001:0 /commandhistory \
+    && { \
+         echo 'export HISTFILE=/commandhistory/.bash_history'; \
+         echo 'if [ -n "$PROMPT_COMMAND" ]; then'; \
+         echo '  PROMPT_COMMAND="$PROMPT_COMMAND;history -a"'; \
+         echo 'else'; \
+         echo '  PROMPT_COMMAND="history -a"'; \
+         echo 'fi'; \
+       } >> "${HOME}/.bashrc"
 
 # ─── UID‑agnostic toolchains: create stable devtools group and set perms ─────
 RUN groupadd -g ${DEVTOOLS_GID} devtools || true \

--- a/docker/Dockerfile.terrarium
+++ b/docker/Dockerfile.terrarium
@@ -699,6 +699,49 @@ RUN ARCH=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
 RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v${TRIVY_VERSION} \
     && trivy version
 
+# --- OpenShift CLI (oc) ------------------------------------------------------
+ARG OC_VERSION=4.19.0
+RUN arch="${TARGETARCH:-$(echo "${TARGETPLATFORM:-linux/amd64}" | cut -d/ -f2)}" \
+    && fetch -o /tmp/oc.tgz \
+       "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux-${arch}-rhel9.tar.gz" \
+    && tar -C /usr/local/bin -xzf /tmp/oc.tgz \
+    && rm -f /tmp/oc.tgz \
+    && oc version --client
+
+# --- OpenStack CLI -----------------------------------------------------------
+ARG OPENSTACK_VENV=/opt/openstack
+ARG OPENSTACK_CLIENT_VERSION=7.1.4
+RUN python -m venv ${OPENSTACK_VENV} \
+    && ${OPENSTACK_VENV}/bin/pip install --no-cache-dir \
+       python-openstackclient==${OPENSTACK_CLIENT_VERSION} \
+       python-barbicanclient \
+    && ln -s ${OPENSTACK_VENV}/bin/openstack /usr/local/bin/openstack \
+    && openstack --version
+
+# --- NPM per-user prefix (avoids sudo for global installs) -------------------
+RUN rm -rf ${HOME}/.npm ${HOME}/.npm-global \
+    && install -d -m 0755 -o 1001 -g 0 \
+       ${HOME}/.npm \
+       ${HOME}/.npm-global \
+       ${HOME}/.npm-global/bin \
+    && printf 'prefix=%s\ncache=%s\n' \
+       "${HOME}/.npm-global" "${HOME}/.npm" \
+       > ${HOME}/.npmrc \
+    && chown 1001:0 ${HOME}/.npmrc
+ENV PATH="${HOME}/.npm-global/bin:${PATH}"
+
+# --- Persistent bash history -------------------------------------------------
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+    && mkdir -p /commandhistory \
+    && touch /commandhistory/.bash_history \
+    && chown -R 1001:0 /commandhistory \
+    && echo "$SNIPPET" >> "${HOME}/.bashrc"
+
+# --- Shell init (zoxide, starship, local bins) --------------------------------
+RUN echo 'eval "$(zoxide init bash)"' >> "${HOME}/.bashrc" \
+    && echo 'eval "$(starship init bash)"' >> "${HOME}/.bashrc" \
+    && echo 'export PATH="$HOME/.local/bin:$PATH"' >> "${HOME}/.bashrc"
+
 # ─── UID‑agnostic toolchains: create stable devtools group and set perms ─────
 RUN groupadd -g ${DEVTOOLS_GID} devtools || true \
     && install -d -m 0775 -o 1001 -g devtools "${HOME}" \

--- a/docker/Dockerfile.terrarium
+++ b/docker/Dockerfile.terrarium
@@ -711,10 +711,11 @@ RUN arch="${TARGETARCH:-$(echo "${TARGETPLATFORM:-linux/amd64}" | cut -d/ -f2)}"
 # --- OpenStack CLI -----------------------------------------------------------
 ARG OPENSTACK_VENV=/opt/openstack
 ARG OPENSTACK_CLIENT_VERSION=7.1.4
+ARG OPENSTACK_BARBICAN_VERSION=7.3.0
 RUN python -m venv ${OPENSTACK_VENV} \
     && ${OPENSTACK_VENV}/bin/pip install --no-cache-dir \
        python-openstackclient==${OPENSTACK_CLIENT_VERSION} \
-       python-barbicanclient==7.3.0 \
+       python-barbicanclient==${OPENSTACK_BARBICAN_VERSION} \
     && ln -s ${OPENSTACK_VENV}/bin/openstack /usr/local/bin/openstack \
     && openstack --version
 

--- a/docker/tests/07_node_npm.bats
+++ b/docker/tests/07_node_npm.bats
@@ -27,16 +27,43 @@ load 'test_helper/common.bash'
 }
 
 @test "npm global install works without sudo" {
-    run npm install -g semver
+    # Use a local package to avoid network dependency
+    tmpdir="$(mktemp -d)"
+
+    cat >"$tmpdir/package.json" <<'PKGJSON'
+{
+  "name": "test-global-install",
+  "version": "1.0.0",
+  "bin": {
+    "test-global-install": "bin/test-global-install"
+  }
+}
+PKGJSON
+
+    mkdir -p "$tmpdir/bin"
+    cat >"$tmpdir/bin/test-global-install" <<'BIN'
+#!/usr/bin/env bash
+echo "ok"
+BIN
+    chmod +x "$tmpdir/bin/test-global-install"
+
+    run npm install -g "$tmpdir"
     assert_success
     # verify the binary was installed in the per-user prefix
-    run bash -c 'test -f "$(npm config get prefix)/bin/semver"'
+    run bash -c 'test -f "$(npm config get prefix)/bin/test-global-install"'
     assert_success
     # cleanup
-    npm uninstall -g semver
+    npm uninstall -g test-global-install
+    rm -rf "$tmpdir"
 }
 
 @test "no root-owned files in npm-global" {
-    run bash -c 'find ~/.npm-global -user root 2>/dev/null | head -1'
+    # Ensure the directory exists so the test cannot pass trivially
+    run bash -c 'test -d "$HOME/.npm-global"'
+    assert_success
+
+    # Verify no root-owned files exist
+    run bash -c 'find "$HOME/.npm-global" -user root -print -quit 2>/dev/null'
+    assert_success
     assert_output ""
 }

--- a/docker/tests/07_node_npm.bats
+++ b/docker/tests/07_node_npm.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+load 'test_helper/common.bash'
+
+# bats file_tags=node,npm
+
+@test "node is on PATH and version is 24.x" {
+    run node --version
+    assert_success
+    assert_output --partial "v24."
+}
+
+@test "npm is on PATH" {
+    run npm --version
+    assert_success
+}
+
+@test "npm global prefix is set to ~/.npm-global" {
+    run npm config get prefix
+    assert_success
+    assert_output --partial ".npm-global"
+}
+
+@test "npm bin directory is on PATH" {
+    run bash -c 'echo "$PATH"'
+    assert_output --partial ".npm-global/bin"
+}
+
+@test "npm global install works without sudo" {
+    run npm install -g semver
+    assert_success
+    # verify the binary was installed in the per-user prefix
+    run bash -c 'test -f "$(npm config get prefix)/bin/semver"'
+    assert_success
+    # cleanup
+    npm uninstall -g semver
+}
+
+@test "no root-owned files in npm-global" {
+    run bash -c 'find ~/.npm-global -user root 2>/dev/null | head -1'
+    assert_output ""
+}

--- a/docker/tests/90_extras.bats
+++ b/docker/tests/90_extras.bats
@@ -15,3 +15,25 @@ load 'test_helper/common.bash'
 @test "yq CLI" { check_binary yq; }
 
 @test "zoxide utility" { check_binary zoxide; }
+
+@test "oc client is present" {
+    run oc version --client
+    assert_success
+}
+
+@test "openstack CLI is installed and on PATH" {
+    run which openstack
+    assert_success
+}
+
+@test "openstack CLI runs and shows version" {
+    run openstack --version
+    assert_success
+    assert_output --partial "openstack"
+}
+
+@test "openstack help includes secret commands (barbican)" {
+    run openstack secret store --help
+    assert_success
+    assert_output --partial "secret"
+}


### PR DESCRIPTION
## Summary

- **OpenShift CLI** (`oc` 4.19.0) — architecture-aware install with `rhel9` URL matching Rocky 9 base
- **OpenStack CLI** (7.1.4) — isolated venv at `/opt/openstack` with `python-barbicanclient` 7.3.0
- **NPM per-user prefix** — `~/.npm-global` prefix, sudo-free global installs, `.npmrc` configured
- **Persistent bash history** — `/commandhistory/.bash_history` volume with `PROMPT_COMMAND`
- **Shell init** — zoxide + starship init and `$HOME/.local/bin` added to `.bashrc`

All items are open-source and useful to any terrarium consumer — this enables the internal ccg-terrarium build to slim down to org-specific items only (Phase 4).

## Test plan

- [x] All 52 bats tests pass (was 42 — 10 new tests added)
- [x] New `07_node_npm.bats` (6 tests): node version, npm prefix, PATH, sudo-free install, no root files
- [x] Extended `90_extras.bats` (+4 tests): oc client, openstack CLI on PATH, version, barbican
- [ ] CI scan workflow passes on push
- [ ] Verify image size delta is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)