### PR TITLE
chore(ci): bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,13 +33,13 @@ jobs:
             suffix: -linux-arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/dump-context
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           flavor: latest=auto,suffix=${{ matrix.suffix }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -126,10 +126,10 @@ jobs:
     permissions: { contents: read, packages: write }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/dump-context
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -141,7 +141,7 @@ jobs:
 
       - name: Generate manifest tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -38,11 +38,11 @@ jobs:
             runner: ubuntu-22.04-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/dump-context
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v5
- Bump `docker/setup-buildx-action` v3 → v4
- Bump `docker/metadata-action` v5 → v6
- Bump `docker/login-action` v3 → v4

Resolves Node.js 20 deprecation warning ahead of the June 2026 deadline when GitHub Actions will force Node.js 24.

## Test plan
- [ ] Verify CI pipeline passes on this PR (build + scan workflows)
- [ ] Confirm no Node.js 20 deprecation warnings in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)