### PR TITLE
chore(ci): bump GHA to Node.js 24 and fix buildx PATH arg

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,13 +33,13 @@ jobs:
             suffix: -linux-arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/dump-context
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           flavor: latest=auto,suffix=${{ matrix.suffix }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -126,10 +126,10 @@ jobs:
     permissions: { contents: read, packages: write }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/dump-context
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -141,7 +141,7 @@ jobs:
 
       - name: Generate manifest tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -106,9 +106,7 @@ jobs:
               --push \
               --sbom=true \
               --cache-from type=gha,scope=${{ matrix.platform }} \
-              $tag_flags \
-              $label_flags \
-              ./docker \
+              $tag_flags $label_flags ./docker \
               && { echo "::endgroup::"; break; } \
               || { echo "::endgroup::"; echo "::warning::Push attempt $attempt failed"; }
             if [ "$attempt" -eq 3 ]; then echo "::error::All 3 push attempts failed"; exit 1; fi

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -38,11 +38,11 @@ jobs:
             runner: ubuntu-22.04-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/dump-context
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v5, `docker/setup-buildx-action` v3 → v4, `docker/metadata-action` v5 → v6, `docker/login-action` v3 → v4 — resolves Node.js 20 deprecation ahead of the June 2026 deadline
- Fix `docker buildx build` missing PATH argument by placing `$tag_flags $label_flags ./docker` on the same line so empty variables don't swallow the context arg

## Test plan
- [ ] Verify CI pipeline passes (build + scan workflows)
- [ ] Confirm no Node.js 20 deprecation warnings in workflow logs
- [ ] Confirm the "Build & push final image" step no longer fails with missing PATH argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)