### PR TITLE
fix(ci): place ./docker on its own line as buildx PATH argument

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -106,7 +106,8 @@ jobs:
               --push \
               --sbom=true \
               --cache-from type=gha,scope=${{ matrix.platform }} \
-              $tag_flags $label_flags ./docker \
+              $tag_flags $label_flags \
+              ./docker \
               && { echo "::endgroup::"; break; } \
               || { echo "::endgroup::"; echo "::warning::Push attempt $attempt failed"; }
             if [ "$attempt" -eq 3 ]; then echo "::error::All 3 push attempts failed"; exit 1; fi


### PR DESCRIPTION
## Summary
- Move `./docker` to its own continuation line in the `docker buildx build` command so it is always recognized as the required PATH argument
- When `$tag_flags` and `$label_flags` expand to empty, having `./docker` on the same line caused it to be swallowed, producing `docker buildx build requires 1 argument`

## Test plan
- [ ] Verify the "Build & push final image" step no longer fails with missing PATH argument
- [ ] Verify CI pipeline passes (build + scan workflows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)