### PR TITLE
fix(ci): use bash arrays for buildx tag/label flags

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -86,15 +86,16 @@ jobs:
           META_TAGS: ${{ steps.meta.outputs.tags }}
           META_LABELS: ${{ steps.meta.outputs.labels }}
         run: |
-          # Build --tag and --label flags from newline-separated metadata outputs
-          tag_flags=""
+          # Build --tag and --label flag arrays from newline-separated metadata outputs.
+          # Arrays preserve values that contain spaces (e.g. label descriptions).
+          tag_args=()
           while IFS= read -r tag; do
-            [ -n "$tag" ] && tag_flags="$tag_flags --tag $tag"
+            [ -n "$tag" ] && tag_args+=(--tag "$tag")
           done <<< "$META_TAGS"
 
-          label_flags=""
+          label_args=()
           while IFS= read -r label; do
-            [ -n "$label" ] && label_flags="$label_flags --label $label"
+            [ -n "$label" ] && label_args+=(--label "$label")
           done <<< "$META_LABELS"
 
           for attempt in 1 2 3; do
@@ -106,7 +107,7 @@ jobs:
               --push \
               --sbom=true \
               --cache-from type=gha,scope=${{ matrix.platform }} \
-              $tag_flags $label_flags \
+              "${tag_args[@]}" "${label_args[@]}" \
               ./docker \
               && { echo "::endgroup::"; break; } \
               || { echo "::endgroup::"; echo "::warning::Push attempt $attempt failed"; }


### PR DESCRIPTION
## Summary
- Switch `tag_flags` / `label_flags` from string concatenation to bash arrays (`tag_args`, `label_args`)
- Expand with `"${tag_args[@]}"` / `"${label_args[@]}"` so values containing spaces (e.g. `org.opencontainers.image.description`) are properly quoted

### Root cause
Label metadata values like `Docker based developer environment for the ODS AWS/AZURE Quickstarter` contain spaces. When expanded via unquoted `$label_flags`, bash word-splits these into separate arguments, producing extra bare words that confuse `docker buildx build` into thinking no PATH argument was provided.

## Test plan
- [ ] Verify the "Build & push final image" step succeeds (no more `requires 1 argument` error)
- [ ] Verify CI pipeline passes end-to-end (build + scan workflows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)