### PR TITLE
fix: redirect GNUPGHOME to ~/.gnupg for VS Code UID remapping

### DIFF
--- a/docker/Dockerfile.terrarium
+++ b/docker/Dockerfile.terrarium
@@ -818,8 +818,12 @@ RUN set -eux; \
     rm -rf /opt/bats-core; \
     bats --version
 
-# Ensure GNUPGHOME is owned by UID 1001 (terrarium) so VS Code GPG agent forwarding works
-RUN chown -R 1001:0 "$GNUPGHOME"
+# --- Redirect GNUPGHOME to ~/.gnupg so VS Code UID remapping works -----------
+# Build-time GNUPGHOME=/opt/keys/gnupg is mode 0700. When updateRemoteUserUID
+# remaps the UID, /opt/keys/gnupg becomes inaccessible. Redirect to ~/.gnupg
+# which lives under $HOME and follows the UID remap automatically.
+RUN install -d -m 0700 -o 1001 -g 0 /home/terrarium/.gnupg
+ENV GNUPGHOME=/home/terrarium/.gnupg
 
 COPY tests /home/terrarium/tests
 


### PR DESCRIPTION
## Problem

The build-time `GNUPGHOME=/opt/keys/gnupg` directory is created with mode `0700` and owned by UID 1001 (`terrarium`). When VS Code's devcontainer feature `updateRemoteUserUID: true` remaps the UID at runtime (typically 1001→1000 on Linux hosts), `/opt/keys/gnupg` becomes inaccessible, causing `EACCES` errors on `S.gpg-agent` and blocking devcontainer lifecycle initialization.

## Solution

Redirect `GNUPGHOME` from `/opt/keys/gnupg` to `~/.gnupg`:

- Create `~/.gnupg` with `install -d -m 0700 -o 1001 -g 0`
- Set `ENV GNUPGHOME=/home/terrarium/.gnupg`

Since `~/.gnupg` lives under `$HOME`, it follows the UID remap automatically. The build-time GPG keyring at `/opt/keys/gnupg` is only used for signature verification during the build stage and has no runtime purpose.

## Testing

- Upstream BATS test 11 ("GNUPGHOME is owned by the active user") uses `$GNUPGHOME` env var, not a hardcoded path, so the redirect works without test changes
- All 65 downstream BATS tests pass
- VS Code devcontainer starts without EACCES errors