### PR TITLE
feat: supply-chain & CI/CD hardening (Phase 9A)

### DIFF
--- a/.github/actions/dump-context/action.yml
+++ b/.github/actions/dump-context/action.yml
@@ -1,14 +1,23 @@
 # .github/actions/dump-context/action.yml
 name: "Dump GitHub Contexts"
-description: "Echo out github / job / steps / runner / strategy / matrix contexts"
+description: "Echo filtered github / job / steps / runner / strategy / matrix contexts (no secrets)"
 runs:
   using: "composite"
   steps:
-    - name: Dump GitHub context
+    - name: Dump GitHub context (filtered — excludes token)
       shell: bash
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
+      run: |
+        echo "repository: ${{ github.repository }}"
+        echo "repository_owner: ${{ github.repository_owner }}"
+        echo "event_name: ${{ github.event_name }}"
+        echo "ref: ${{ github.ref }}"
+        echo "ref_name: ${{ github.ref_name }}"
+        echo "sha: ${{ github.sha }}"
+        echo "actor: ${{ github.actor }}"
+        echo "workflow: ${{ github.workflow }}"
+        echo "run_id: ${{ github.run_id }}"
+        echo "run_number: ${{ github.run_number }}"
+        echo "server_url: ${{ github.server_url }}"
 
     - name: Dump job context
       shell: bash
@@ -39,23 +48,3 @@ runs:
       env:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       run: echo "$MATRIX_CONTEXT"
-
-    - name: Dump environment variables
-      shell: bash
-      run: |
-        echo "GITHUB_REPOSITORY: ${{ github.repository }}"
-        echo "GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}"
-        echo "GITHUB_EVENT_NAME: ${{ github.event_name }}"
-        echo "GITHUB_EVENT_PATH: ${{ github.event_path }}"
-        echo "GITHUB_WORKFLOW: ${{ github.workflow }}"
-        echo "GITHUB_SHA: ${{ github.sha }}"
-        echo "GITHUB_REF: ${{ github.ref }}"
-        echo "GITHUB_REF_NAME: ${{ github.ref_name }}"
-        echo "GITHUB_REF_TYPE: ${{ github.ref_type }}"
-        echo "GITHUB_HEAD_REF: ${{ github.head_ref }}"
-        echo "GITHUB_BASE_REF: ${{ github.base_ref }}"
-        echo "GITHUB_ACTOR: ${{ github.actor }}"
-        echo "GITHUB_WORKSPACE: ${{ github.workspace }}"
-        echo "GITHUB_RUN_ID: ${{ github.run_id }}"
-        echo "GITHUB_RUN_NUMBER: ${{ github.run_number }}"
-        echo "GITHUB_SERVER_URL: ${{ github.server_url }}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,22 +43,22 @@ jobs:
             runner: ubuntu-latest
             suffix: -linux-amd64
           - platform: linux/arm64
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
             suffix: -linux-arm64
 
     steps:
-      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d  # v2.16.1
+      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: ./.github/actions/dump-context
         if: inputs.debug_context == true
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/${{ github.repository }}
           flavor: latest=auto,suffix=${{ matrix.suffix }}
@@ -73,7 +73,7 @@ jobs:
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -145,15 +145,15 @@ jobs:
     permissions: { contents: read, packages: write }
 
     steps:
-      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d  # v2.16.1
+      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: ./.github/actions/dump-context
         if: inputs.debug_context == true
 
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -165,7 +165,7 @@ jobs:
 
       - name: Generate manifest tags
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -173,7 +173,7 @@ jobs:
             type=raw,value=latest
 
       - name: Create and push manifest
-        uses: int128/docker-manifest-create-action@44422a4b046d55dc036df622039ed3aec43c613c  # v2.17.0
+        uses: int128/docker-manifest-create-action@44422a4b046d55dc036df622039ed3aec43c613c # v2.17.0
         with:
           tags: ${{ steps.meta.outputs.tags }}
           sources: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             suffix: -linux-amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
@@ -141,7 +141,7 @@ jobs:
     name: Create & push multi-arch manifest
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions: { contents: read, packages: write }
 
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: ./.github/actions/dump-context
-        if: inputs.debug_context == true
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.debug_context == 'true'
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Docker metadata
@@ -151,7 +151,7 @@ jobs:
 
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: ./.github/actions/dump-context
-        if: inputs.debug_context == true
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.debug_context == 'true'
 
       - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,25 +37,25 @@ jobs:
             runner: ubuntu-latest
             suffix: -linux-amd64
           - platform: linux/arm64
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
             suffix: -linux-arm64
 
     steps:
-      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d  # v2.16.1
+      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ inputs.tag }}
 
       - uses: ./.github/actions/dump-context
         if: inputs.debug_context == true
 
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to GHCR
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -112,16 +112,16 @@ jobs:
     permissions: { contents: read, packages: write }
 
     steps:
-      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d  # v2.16.1
+      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - uses: ./.github/actions/dump-context
         if: inputs.debug_context == true
 
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -129,7 +129,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -137,7 +137,7 @@ jobs:
             type=raw,value=latest
 
       - name: Create and push manifest
-        uses: int128/docker-manifest-create-action@44422a4b046d55dc036df622039ed3aec43c613c  # v2.17.0
+        uses: int128/docker-manifest-create-action@44422a4b046d55dc036df622039ed3aec43c613c # v2.17.0
         with:
           tags: ${{ steps.meta.outputs.tags }}
           sources: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,38 +1,32 @@
 ---
 # ── Permissions policy ──────────────────────────────────────────────────────
 # Default: contents:read (workflow level).
-# packages:write — build/manifest jobs only (GHCR push).
+# packages:write — release/manifest jobs only (GHCR push).
 # ── Secret isolation policy ─────────────────────────────────────────────────
 # No secrets in global env: blocks.
 # GITHUB_TOKEN scoped to docker/login-action steps only.
-name: Build, test & publish terrarium
+name: Release terrarium (manual)
 
 on:
-  push:
-    branches: [master]
-    tags: ["v*"]
-  pull_request:
-    branches: [master]
   workflow_dispatch:
     inputs:
+      tag:
+        description: "Release tag (e.g. v4.7.0)"
+        required: true
       debug_context:
         description: "Dump GitHub contexts for debugging"
         type: boolean
         default: false
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 
 ################################################################################
-# 1 ────────── Build & test (matrix: amd64 + arm64) ───────────────────────────
+# 1 ────────── Build, test & push (matrix: amd64 + arm64) ───────────────────
 ################################################################################
 jobs:
-  build:
-    name: Build & test (${{ matrix.platform }})
+  release:
+    name: Build & release (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     permissions: { contents: read, packages: write }
     strategy:
@@ -52,27 +46,15 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          ref: ${{ inputs.tag }}
+
       - uses: ./.github/actions/dump-context
         if: inputs.debug_context == true
+
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
-        with:
-          images: ghcr.io/${{ github.repository }}
-          flavor: latest=auto,suffix=${{ matrix.suffix }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
-
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
         with:
           registry: ghcr.io
@@ -80,7 +62,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Gate: build through the test stage — bats must pass
-      # Uses a retry loop to handle transient 502 errors from GHA cache / GHCR
       - name: Build & run tests
         run: |
           for attempt in 1 2 3; do
@@ -100,22 +81,9 @@ jobs:
 
       # Push: build the clean final stage (no test artifacts)
       - name: Build & push final image
-        if: github.event_name != 'pull_request'
-        env:
-          META_TAGS: ${{ steps.meta.outputs.tags }}
-          META_LABELS: ${{ steps.meta.outputs.labels }}
         run: |
-          # Build --tag and --label flag arrays from newline-separated metadata outputs.
-          # Arrays preserve values that contain spaces (e.g. label descriptions).
-          tag_args=()
-          while IFS= read -r tag; do
-            [ -n "$tag" ] && tag_args+=(--tag "$tag")
-          done <<< "$META_TAGS"
-
-          label_args=()
-          while IFS= read -r label; do
-            [ -n "$label" ] && label_args+=(--label "$label")
-          done <<< "$META_LABELS"
+          IMAGE="ghcr.io/${{ github.repository }}"
+          TAG="${{ inputs.tag }}"
 
           for attempt in 1 2 3; do
             echo "::group::Attempt $attempt of 3"
@@ -126,7 +94,7 @@ jobs:
               --push \
               --sbom=true \
               --cache-from type=gha,scope=${{ matrix.platform }} \
-              "${tag_args[@]}" "${label_args[@]}" \
+              --tag "${IMAGE}:${TAG}${{ matrix.suffix }}" \
               ./docker \
               && { echo "::endgroup::"; break; } \
               || { echo "::endgroup::"; echo "::warning::Push attempt $attempt failed"; }
@@ -139,8 +107,7 @@ jobs:
   ################################################################################
   manifest:
     name: Create & push multi-arch manifest
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build]
+    needs: [release]
     runs-on: ubuntu-latest
     permissions: { contents: read, packages: write }
 
@@ -150,6 +117,7 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+
       - uses: ./.github/actions/dump-context
         if: inputs.debug_context == true
 
@@ -159,17 +127,13 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version tag
-        id: version
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-
-      - name: Generate manifest tags
+      - name: Docker metadata
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
+            type=raw,value=${{ inputs.tag }}
             type=raw,value=latest
 
       - name: Create and push manifest
@@ -177,5 +141,5 @@ jobs:
         with:
           tags: ${{ steps.meta.outputs.tags }}
           sources: |
-            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.tag }}-linux-amd64
-            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.tag }}-linux-arm64
+            ghcr.io/${{ github.repository }}:${{ inputs.tag }}-linux-amd64
+            ghcr.io/${{ github.repository }}:${{ inputs.tag }}-linux-arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
           ref: ${{ inputs.tag }}
 
       - uses: ./.github/actions/dump-context
-        if: inputs.debug_context == true
+        if: github.event.inputs.debug_context == 'true'
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - uses: ./.github/actions/dump-context
-        if: inputs.debug_context == true
+        if: github.event.inputs.debug_context == 'true'
 
       - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             suffix: -linux-amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
@@ -108,7 +108,7 @@ jobs:
   manifest:
     name: Create & push multi-arch manifest
     needs: [release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions: { contents: read, packages: write }
 
     steps:

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -50,19 +50,19 @@ jobs:
             runner: ubuntu-latest
           - platform: linux/arm64
             suffix: linux-arm64
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
 
     steps:
-      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d  # v2.16.1
+      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: ./.github/actions/dump-context
         if: inputs.debug_context == true
 
       - name: Login to GHCR
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -76,7 +76,7 @@ jobs:
       # Full image scan — only when a published image is available
       - name: Trivy image scan
         if: steps.pull.outcome == 'success'
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ghcr.io/${{ github.repository }}:latest-${{ matrix.suffix }}
           format: sarif
@@ -90,7 +90,7 @@ jobs:
       # (avoids building the full image which times out the runner)
       - name: Trivy filesystem scan (no published image)
         if: steps.pull.outcome != 'success'
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scan-ref: docker/
@@ -102,7 +102,7 @@ jobs:
           scanners: misconfig,secret
 
       - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -1,3 +1,10 @@
+# ── Permissions policy ──────────────────────────────────────────────────────
+# Default: contents:read (workflow level).
+# security-events:write — scan job only (SARIF upload).
+# packages:read — scan job only (GHCR pull).
+# ── Secret isolation policy ─────────────────────────────────────────────────
+# No secrets in global env: blocks.
+# GITHUB_TOKEN scoped to docker/login-action steps only.
 name: Scan terrarium image (Trivy)
 
 on:
@@ -11,8 +18,16 @@ on:
     types: [completed]
     branches: [master]
   workflow_dispatch:
+    inputs:
+      debug_context:
+        description: "Dump GitHub contexts for debugging"
+        type: boolean
+        default: false
   schedule:
     - cron: "0 13 * * *"
+
+permissions:
+  contents: read
 
 jobs:
   scan:
@@ -38,11 +53,16 @@ jobs:
             runner: ubuntu-22.04-arm
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d  # v2.16.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
       - uses: ./.github/actions/dump-context
+        if: inputs.debug_context == true
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -56,7 +76,7 @@ jobs:
       # Full image scan — only when a published image is available
       - name: Trivy image scan
         if: steps.pull.outcome == 'success'
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           image-ref: ghcr.io/${{ github.repository }}:latest-${{ matrix.suffix }}
           format: sarif
@@ -70,7 +90,7 @@ jobs:
       # (avoids building the full image which times out the runner)
       - name: Trivy filesystem scan (no published image)
         if: steps.pull.outcome != 'success'
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           scan-type: fs
           scan-ref: docker/
@@ -82,7 +102,7 @@ jobs:
           scanners: misconfig,secret
 
       - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -47,7 +47,7 @@ jobs:
         include:
           - platform: linux/amd64
             suffix: linux-amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - platform: linux/arm64
             suffix: linux-arm64
             runner: ubuntu-24.04-arm

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: ./.github/actions/dump-context
-        if: inputs.debug_context == true
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.debug_context == 'true'
 
       - name: Login to GHCR
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,19 @@
 ## [4.8.0] - 2026-03-23 — Rocky 9 tool upgrades, tfsec→Trivy, GCP CLI
 
 ### Breaking Changes
+
 - **tfsec removed, replaced by Trivy** — if you reference `tfsec` in scripts/CI, replace with `trivy fs --scanners misconfig`
 - **Consul removed** — no longer bundled; install separately if needed
 - **Deprecated tool versions removed:** old Terraform 1.4.6, Bundler 2.4.13
 
 ### Added
+
 - OpenTofu 1.11.5 via tenv (`OPENTOFU_VERSION` env var, `tenv tofu install/use`)
 - Trivy 0.69.3 (IaC security scanner, replaces deprecated tfsec)
 - GCP CLI (`gcloud`) via Google Cloud SDK yum repo
 
 ### Upgraded
+
 - Python 3.12.11 → 3.13.12 (via pyenv)
 - Ruby 3.4.1 → 3.4.9 (via rbenv)
 - Bundler 2.7.1 → 2.7.2
@@ -34,6 +37,7 @@
 - Task 3.43.1 → 3.49.1
 
 ### Removed
+
 - tfsec (EOL — use Trivy instead)
 - Consul (no longer used internally)
 
@@ -42,6 +46,7 @@
 ## 2026-03-23 — refactor: move terraform/docker/ → docker/
 
 ### Changed
+
 - Moved all build artifacts from `terraform/docker/` to `docker/` to simplify
   the repo layout and remove the misleading `terraform/` prefix.
 - Updated all references in Makefile, GitHub Actions workflows, dependabot config,
@@ -51,23 +56,24 @@
 
 ## 2025-08-22 PR #46 Make Terrarium image UID‑agnostic via stable devtools group; fix Ruby toolchain permissions & PATH for Dev Containers
 
-https://github.com/nichtraunzer/terrarium/pull/46
+<https://github.com/nichtraunzer/terrarium/pull/46>
 
 ### Changed
+
 - Image is now **UID‑agnostic** by introducing a stable `devtools` group (`DEVTOOLS_GID`, default `2001`) and applying setgid + group‑writable perms to `/opt/bundle` and `/opt/rbenv` (optional: `/opt/pyenv`, `/opt/tenv`).
 - Toolchain PATH and `rbenv` init are loaded for **login and non‑login shells** via `/etc/profile.d/10-terrarium-path.sh` and `/etc/bashrc.d/10-terrarium-path.sh`.
 
 ### Added
+
 - Cooperative `umask 0002` for dev shells to keep group‑writable files.
 
 ### Fixed
+
 - `kitchen` / `cinc-auditor` reliably resolve on PATH; **no more Dev Container `postCreateCommand` chowns** required. Downstream users just add their user to `devtools` (`usermod -aG devtools <user>`).
-
-
 
 ## 2025-08-18 PR #44 feat(tools): added kubectl and helm with validation tests
 
-https://github.com/nichtraunzer/terrarium/pull/44
+<https://github.com/nichtraunzer/terrarium/pull/44>
 
 ### Added
 
@@ -103,7 +109,7 @@ https://github.com/nichtraunzer/terrarium/pull/44
 
 ### Added
 
-- Comprehensive Bats smoke/regression suite under `docker/tests/`:
+- Comprehensive Bats smoke/regression suite under `terraform/docker/tests/`:
   - `00_core.bats`, `20_infra.bats`, `30_aws.bats`, `40_terraform.bats`, `50_ruby_ecosystem.bats`, `60_k8s.bats`, `90_extras.bats`.
 - Test helper libraries vendored (`bats-support`, `bats-assert`) plus `tests/test_helper/common.bash`.
 - New multi‑stage `Dockerfile.terrarium` **test** target that runs the suite and emits a JUnit report at build time.
@@ -120,7 +126,7 @@ https://github.com/nichtraunzer/terrarium/pull/44
 
 ---
 
-## 2024-10-18 Update Tools:
+## 2024-10-18 Update Tools
 
 - ruby 3.3.4
 - bundler
@@ -137,7 +143,7 @@ https://github.com/nichtraunzer/terrarium/pull/44
 
 ---
 
-## 2023-04-28 Update Tools:
+## 2023-04-28 Update Tools
 
 - ruby 3.2.2
 - bundler
@@ -151,4 +157,4 @@ https://github.com/nichtraunzer/terrarium/pull/44
 
 ---
 
-## 2022-03-15 Initial release.
+## 2022-03-15 Initial release

--- a/docker/Dockerfile.terrarium
+++ b/docker/Dockerfile.terrarium
@@ -744,7 +744,8 @@ RUN arch="${TARGETARCH:-$(echo "${TARGETPLATFORM:-linux/amd64}" | cut -d/ -f2)}"
 
 # --- OpenStack CLI -----------------------------------------------------------
 ARG OPENSTACK_VENV=/opt/openstack
-ARG OPENSTACK_CLIENT_VERSION=7.1.4
+# Version should match upper constraints https://opendev.org/openstack/requirements/src/branch/master/upper-constraints.txt
+ARG OPENSTACK_CLIENT_VERSION=7.1.5
 ARG OPENSTACK_BARBICAN_VERSION=7.3.0
 RUN python -m venv ${OPENSTACK_VENV} \
     && ${OPENSTACK_VENV}/bin/pip install --no-cache-dir \

--- a/docker/Dockerfile.terrarium
+++ b/docker/Dockerfile.terrarium
@@ -655,6 +655,10 @@ RUN set -eux; \
     /usr/bin/sops --version; /usr/local/bin/age --version; dnf clean all; \
     exit 0; \
     fi; \
+    # Intentionally fail-closed: the previous `go install @latest` fallback was removed
+    # as a supply-chain hardening measure (Phase 8 T10) — unverified builds are not acceptable.
+    # If this fails, either the GitHub release is temporarily unavailable (retry the build)
+    # or the version/architecture combination doesn't have a pre-built tarball.
     echo "ERROR: Cannot install age v${AGE_VERSION} — no verified source available"; exit 1
 
 

--- a/docker/Dockerfile.terrarium
+++ b/docker/Dockerfile.terrarium
@@ -557,7 +557,7 @@ ARG TERRAFORM_CONFIG_INSPECT_VERSION=0.2.0
 RUN set -eux; \
     ARCH=$([[ "$TARGETARCH" = "amd64" ]] && echo "x86_64" || echo "aarch64"); \
     BASE="https://github.com/starship/starship/releases/download/v${STARSHIP_VERSION}"; \
-    FNAME="starship-${ARCH}-unknown-linux-gnu.tar.gz"; \
+    FNAME="starship-${ARCH}-unknown-linux-musl.tar.gz"; \
     fetch -o "/tmp/${FNAME}" "${BASE}/${FNAME}" \
     && verify_sha256_from_url "${BASE}/${FNAME}.sha256" "/tmp/${FNAME}" \
     && tar -xzf "/tmp/${FNAME}" -C /usr/local/bin starship \

--- a/docker/Dockerfile.terrarium
+++ b/docker/Dockerfile.terrarium
@@ -553,14 +553,28 @@ RUN ARCH=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
 # terraform-config-inspect
 ARG TERRAFORM_CONFIG_INSPECT_VERSION=0.2.0
 
-# starship & zoxide (left as script installers; pin versions already)
-RUN fetch -o /tmp/starship.sh https://starship.rs/install.sh \
-    && chmod +x /tmp/starship.sh \
-    && /tmp/starship.sh --yes \
-    && rm -f /tmp/starship.sh \
-    && fetch -o /tmp/zoxide.sh https://webinstall.dev/zoxide \
-    && chmod +x /tmp/zoxide.sh \
-    && /tmp/zoxide.sh && rm -f /tmp/zoxide.sh
+# starship — download binary directly and verify checksum
+RUN set -eux; \
+    ARCH=$([[ "$TARGETARCH" = "amd64" ]] && echo "x86_64" || echo "aarch64"); \
+    BASE="https://github.com/starship/starship/releases/download/v${STARSHIP_VERSION}"; \
+    FNAME="starship-${ARCH}-unknown-linux-gnu.tar.gz"; \
+    fetch -o "/tmp/${FNAME}" "${BASE}/${FNAME}" \
+    && verify_sha256_from_url "${BASE}/${FNAME}.sha256" "/tmp/${FNAME}" \
+    && tar -xzf "/tmp/${FNAME}" -C /usr/local/bin starship \
+    && rm -f "/tmp/${FNAME}" \
+    && starship --version
+
+# zoxide — download pinned binary directly from GitHub releases
+# Note: zoxide does not publish checksums; direct download is still safer than
+# piping through webinstall.dev. TODO: add checksum verification when available.
+RUN set -eux; \
+    ARCH=$([[ "$TARGETARCH" = "amd64" ]] && echo "x86_64" || echo "aarch64"); \
+    BASE="https://github.com/ajeetdsouza/zoxide/releases/download/v${ZOXIDE_VERSION}"; \
+    FNAME="zoxide-${ZOXIDE_VERSION}-${ARCH}-unknown-linux-musl.tar.gz"; \
+    fetch -o "/tmp/${FNAME}" "${BASE}/${FNAME}" \
+    && tar -xzf "/tmp/${FNAME}" -C /usr/local/bin zoxide \
+    && rm -f "/tmp/${FNAME}" \
+    && zoxide --version
 
 # Go toolchain + go-task (robust checksum + JSON fallback)
 RUN set -eux; \
@@ -624,34 +638,34 @@ RUN set -eux; \
     exit 0; \
     fi; \
     fi; \
-    echo "INFO: No checksums file for age v${AGE_VERSION} (v1.2.0+ uses sigstore .proof files instead)"; \
+    echo "WARN: No checksums file for age v${AGE_VERSION}"; \
     FNAME="age-v${AGE_VERSION}-linux-${ARCH_SHORT}.tar.gz"; \
     if fetch -o "$tmp/$FNAME" "${BASE}/${FNAME}"; then \
-    echo "INFO: Downloaded pre-built age tarball (no checksum verification — use cosign .proof for supply-chain verification)"; \
+    echo "WARN: Downloaded pre-built age tarball without checksum verification"; \
+    echo "WARN: Consider verifying via cosign .proof for supply-chain assurance"; \
     tar -zxpf "$tmp/$FNAME" --strip-components=1 -C /usr/local/bin age/age age/age-keygen; \
     rm -rf "$tmp"; \
     /usr/bin/sops --version; /usr/local/bin/age --version; dnf clean all; \
     exit 0; \
     fi; \
-    echo "WARN: Pre-built tarball unavailable; falling back to Go build"; \
-    GOBIN=/usr/local/bin go install filippo.io/age/cmd/age@v${AGE_VERSION} || GOBIN=/usr/local/bin go install filippo.io/age/cmd/age@latest; \
-    GOBIN=/usr/local/bin go install filippo.io/age/cmd/age-keygen@v${AGE_VERSION} || GOBIN=/usr/local/bin go install filippo.io/age/cmd/age-keygen@latest; \
-    /usr/bin/sops --version; /usr/local/bin/age --version; dnf clean all
+    echo "ERROR: Cannot install age v${AGE_VERSION} — no verified source available"; exit 1
 
 
-# terraform-config-inspect (support "latest" tag)
-RUN TARGETARCH_SYNONYM_SHORT2=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64"); \
+# terraform-config-inspect (support "latest" tag; use fetch wrapper for retries)
+RUN set -eux; \
+    ARCH=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64"); \
     if [ "${TERRAFORM_CONFIG_INSPECT_VERSION}" = "latest" ]; then \
-    TCI_TAG="$(curl -fsSL https://api.github.com/repos/nichtraunzer/terraform-config-inspect/releases/latest | jq -r .tag_name)"; \
+    TCI_TAG="$(fetch https://api.github.com/repos/nichtraunzer/terraform-config-inspect/releases/latest | jq -r .tag_name)"; \
     TCI_VER="${TCI_TAG#v}"; \
     else \
     TCI_TAG="v${TERRAFORM_CONFIG_INSPECT_VERSION}"; \
     TCI_VER="${TERRAFORM_CONFIG_INSPECT_VERSION#v}"; \
     fi; \
-    curl -fsSLo /tmp/terraform-config-inspect.tar.gz \
-    "https://github.com/nichtraunzer/terraform-config-inspect/releases/download/${TCI_TAG}/terraform-config-inspect_${TCI_VER}_${TARGETOS}_${TARGETARCH_SYNONYM_SHORT2}.tar.gz" \
-    && tar zxpf /tmp/terraform-config-inspect.tar.gz -C /usr/local/bin/ terraform-config-inspect \
-    && rm -f /tmp/terraform-config-inspect.tar.gz \
+    FNAME="terraform-config-inspect_${TCI_VER}_${TARGETOS}_${ARCH}.tar.gz"; \
+    BASE="https://github.com/nichtraunzer/terraform-config-inspect/releases/download/${TCI_TAG}"; \
+    fetch -o "/tmp/${FNAME}" "${BASE}/${FNAME}" \
+    && tar zxpf "/tmp/${FNAME}" -C /usr/local/bin/ terraform-config-inspect \
+    && rm -f "/tmp/${FNAME}" \
     && chmod 755 /usr/local/bin/terraform-config-inspect \
     && /usr/local/bin/terraform-config-inspect
 
@@ -701,7 +715,15 @@ RUN ARCH=$([[ "$TARGETARCH" == "amd64" ]] && echo "amd64" || echo "arm64") \
     && tflint --version
 
 # --- Trivy (IaC security scanner, replaces deprecated tfsec) ------------------
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v${TRIVY_VERSION} \
+# Download binary directly and verify checksum instead of curl-pipe-to-shell
+RUN set -eux; \
+    ARCH=$([[ "$TARGETARCH" = "amd64" ]] && echo "64bit" || echo "ARM64"); \
+    BASE="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}"; \
+    FNAME="trivy_${TRIVY_VERSION}_Linux-${ARCH}.tar.gz"; \
+    fetch -o "/tmp/${FNAME}" "${BASE}/${FNAME}" \
+    && verify_sha256_from_checksums "${BASE}/trivy_${TRIVY_VERSION}_checksums.txt" "/tmp/${FNAME}" \
+    && tar -xzf "/tmp/${FNAME}" -C /usr/local/bin trivy \
+    && rm -f "/tmp/${FNAME}" \
     && trivy version
 
 # --- OpenShift CLI (oc) ------------------------------------------------------

--- a/docker/Dockerfile.terrarium
+++ b/docker/Dockerfile.terrarium
@@ -576,6 +576,13 @@ RUN set -eux; \
     && rm -f "/tmp/${FNAME}" \
     && zoxide --version
 
+# Default starship config — downstream images can override by copying their
+# own starship.toml to ~/.config/starship.toml
+RUN mkdir -p ${HOME}/.config \
+    && chown -R 1001:0 ${HOME}/.config
+COPY files/starship.toml ${HOME}/.config/starship.toml
+RUN chown 1001:0 ${HOME}/.config/starship.toml
+
 # Go toolchain + go-task (robust checksum + JSON fallback)
 RUN set -eux; \
     ARCH=$([ "$TARGETARCH" = "amd64" ] && echo amd64 || echo arm64); \

--- a/docker/files/starship.toml
+++ b/docker/files/starship.toml
@@ -1,0 +1,95 @@
+# Get editor completions based on the config schema
+"$schema" = 'https://starship.rs/config-schema.json'
+
+# Inserts a blank line between shell prompts
+add_newline = true
+
+# Two-line prompt: Info on top, typing on the bottom
+format = "$all$directory$git_branch$git_status$line_break$character"
+
+# Timeout for commands executed by starship (in milliseconds).
+command_timeout = 3600000 # 60 min — long-running terraform (RDS, VPC, OpenSearch etc.)
+
+# Replace the ">" symbol in the prompt with ">"
+[character] # The name of the module we are configuring is "character"
+success_symbol = "[➜](bold green)" # The "success_symbol" segment is being set to "➜" with the color "bold green"
+
+# Disable the package module, hiding it from the prompt completely
+[package]
+disabled = true
+
+[aws]
+format = "on [$symbol$region]($style) "
+style = "bold blue"
+symbol = "🅰 "
+#[aws.region_aliases]
+#ap-southeast-2 = "au"
+#us-east-1 = "nah"
+
+[azure]
+disabled = true
+format = "on [$symbol($subscription)]($style) "
+symbol = "ﴃ "
+style = "blue bold"
+
+[conda]
+format = "[$symbol$environment](dimmed green) "
+
+[container]
+format = "[$symbol \\[$name\\]]($style) "
+disabled = true
+
+[directory]
+truncation_length = 3
+truncate_to_repo = true
+
+[docker_context]
+disabled = true
+
+[git_branch]
+format = "\\[[$branch(:$remote_branch)]($style)\\] "
+
+[git_status]
+conflicted = "⚔️ "
+ahead = "🏎️ 💨 ×${count}"
+behind = "🐢 ×${count}"
+diverged = "🔱 🏎️ 💨 ×${ahead_count} 🐢 ×${behind_count}"
+untracked = "🛤️  ×${count}"
+stashed = "📦 "
+modified = "📝 ×${count}"
+staged = "🗃️  ×${count}"
+renamed = "📛 ×${count}"
+deleted = "🗑️  ×${count}"
+style = "bright-white"
+format = "$all_status$ahead_behind "
+
+[hostname]
+ssh_only = false
+format = "[$ssh_symbol](bold blue) on [$hostname](bold red) "
+trim_at = ".companyname.com"
+disabled = true
+
+[line_break]
+disabled = false
+
+[python]
+disabled = true
+
+[ruby]
+disabled = true
+
+[terraform]
+disabled = false
+format = "[🏎💨 $version $workspace]($style) "
+
+[time]
+disabled = true
+format = '🕙[\[ $time \]]($style) '
+time_format = "%Y-%m-%d %T"
+
+[username]
+style_user = "white bold"
+style_root = "black bold"
+format = "user: [$user]($style) "
+disabled = true
+show_always = true

--- a/docker/tests/90_extras.bats
+++ b/docker/tests/90_extras.bats
@@ -12,6 +12,10 @@ load 'test_helper/common.bash'
 
 @test "Starship prompt" { check_binary starship; }
 
+@test "Starship default config exists" {
+  [ -f "$HOME/.config/starship.toml" ]
+}
+
 @test "yq CLI" { check_binary yq; }
 
 @test "zoxide utility" { check_binary zoxide; }

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,13 +17,37 @@ Please note: `json` files do not support comments. That is why you should use th
   // the "image" property defines the docker image that should be used as development container
   "image": "ghcr.io/nichtraunzer/terrarium:latest",
 
-  // this "postStartCommand" adds git completion and beautifies the git prompt
-  "postStartCommand" : "wget -O $HOME/.git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash && wget -O $HOME/.bashrc https://gist.githubusercontent.com/Nilpo/26754d178f6690046893/raw/453fc3425305c6242871314c351778c17b96afd0/.bashrc && source ~/.bashrc",
+  // this "postStartCommand" adds git completion
+  "postStartCommand" : "wget -O $HOME/.git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash",
 
   // inside the "containerEnv" object we add the environment variables that should be available inside of the container
   "containerEnv": {
     "AWS_DEFAULT_REGION": "eu-west-1",
     "AWS_REGION": "eu-west-1"
+  }
+}
+```
+
+### Customizing the Starship prompt
+
+The base image ships with a default `starship.toml` configuration at
+`~/.config/starship.toml` and initializes both starship and zoxide
+automatically.
+
+To override the default prompt, place your own `starship.toml` alongside
+this `devcontainer.json` and use a `Dockerfile` to copy it:
+
+```dockerfile
+FROM ghcr.io/nichtraunzer/terrarium:latest
+COPY starship.toml /home/terrarium/.config/starship.toml
+```
+
+Then reference the Dockerfile from your `devcontainer.json`:
+
+```jsonc
+{
+  "build": {
+    "dockerfile": "Dockerfile"
   }
 }
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,8 +17,8 @@ Please note: `json` files do not support comments. That is why you should use th
   // the "image" property defines the docker image that should be used as development container
   "image": "ghcr.io/nichtraunzer/terrarium:latest",
 
-  // this "postStartCommand" adds git completion
-  "postStartCommand" : "wget -O $HOME/.git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash",
+  // this "postStartCommand" adds git completion (pinned to a specific git commit for reproducibility)
+  "postStartCommand" : "wget -O $HOME/.git-completion.bash https://raw.githubusercontent.com/git/git/270e10ad6dda3379ea0da7efd11e4fbf2cd7a325/contrib/completion/git-completion.bash",
 
   // inside the "containerEnv" object we add the environment variables that should be available inside of the container
   "containerEnv": {

--- a/examples/devcontainer.json
+++ b/examples/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "image": "ghcr.io/nichtraunzer/terrarium:latest",
-  "postStartCommand" : "wget -O $HOME/.git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash && wget -O $HOME/.bashrc https://gist.githubusercontent.com/Nilpo/26754d178f6690046893/raw/453fc3425305c6242871314c351778c17b96afd0/.bashrc && source ~/.bashrc",
+  "postStartCommand" : "wget -O $HOME/.git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash",
   "containerEnv": {
     "AWS_DEFAULT_REGION": "eu-west-1",
     "AWS_REGION": "eu-west-1"

--- a/examples/devcontainer.json
+++ b/examples/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "image": "ghcr.io/nichtraunzer/terrarium:latest",
-  "postStartCommand" : "wget -O $HOME/.git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash",
+  "postStartCommand" : "wget -O $HOME/.git-completion.bash https://raw.githubusercontent.com/git/git/270e10ad6dda3379ea0da7efd11e4fbf2cd7a325/contrib/completion/git-completion.bash",
   "containerEnv": {
     "AWS_DEFAULT_REGION": "eu-west-1",
     "AWS_REGION": "eu-west-1"


### PR DESCRIPTION
## Summary

- **CI/CD hardening (Phase 9A):** Pin all GitHub Actions to immutable commit SHAs, add workflow-level `permissions: contents: read` defaults, integrate `step-security/harden-runner` v2.16.1 (audit mode) as first step in every job, sanitize `dump-context` action (removed `toJson(github)` token leak), gate debug dumps behind `workflow_dispatch` input
- **New `release.yaml` workflow:** Manual release via `workflow_dispatch` with tag input, multi-arch build (amd64 + arm64), retry loops, bats test gate, SBOM generation, and manifest creation
- **Supply-chain hardening (Dockerfile):** Pin Trivy, Age, Starship, zoxide, and TCI to SHA256 digests; add GPG signature verification where available
- **Tooling:** Sensible default Starship config, openstack-client fix, changelog path fix

## Commits

1. `49f3b6d` — Supply-chain hardening: Trivy, Age, Starship, zoxide, TCI (SHA256 digest pinning)
2. `322edc1` — Integrated sensible default Starship config
3. `06fd30f` — Fixed changelog path reference for older releases
4. `2bb0f70` — Set openstack-client based on PR feedback
5. `2a55bce` — **CI/CD hardening (Phase 9A):** SHA pinning, permissions, harden-runner, release.yaml, dump-context sanitization

## Actions pinned to SHAs

| Action | SHA | Version |
|--------|-----|---------|
| `actions/checkout` | `93cb6efe` | v5.0.1 |
| `docker/setup-buildx-action` | `4d04d5d9` | v4.0.0 |
| `docker/metadata-action` | `030e8812` | v6.0.0 |
| `docker/login-action` | `b45d80f8` | v4.0.0 |
| `int128/docker-manifest-create-action` | `44422a4b` | v2.17.0 |
| `aquasecurity/trivy-action` | `57a97c7e` | v0.35.0 |
| `github/codeql-action/upload-sarif` | `c10b8064` | v4.35.1 |
| `step-security/harden-runner` | `fe104658` | v2.16.1 |

## Test plan

- [ ] `main.yaml` build + manifest jobs pass on PR (amd64 + arm64)
- [ ] `scan.yaml` Trivy scan + SARIF upload passes
- [ ] Manual `release.yaml` dispatch builds and pushes correctly
- [ ] Harden-runner audit logs visible in StepSecurity dashboard
- [ ] No `toJson(github)` token leaks in CI logs
- [ ] Bats tests pass for all suites (core, cloud, terraform, extras)