### PR TITLE
feat(ci): release workflow hardening (v4.8.1)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,11 +9,17 @@
 name: Release terrarium (manual)
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
         description: "Release tag (e.g. v4.7.0)"
         required: true
+      update_latest:
+        description: "Update the 'latest' tag (auto: false for pre-releases)"
+        type: boolean
+        default: true
       debug_context:
         description: "Dump GitHub contexts for debugging"
         type: boolean
@@ -53,7 +59,12 @@ jobs:
 
       - name: Ensure tag exists (create on HEAD if missing)
         run: |
-          TAG="${{ inputs.tag }}"
+          # Resolve tag from release event or workflow_dispatch input
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG="${{ inputs.tag }}"
+          fi
 
           # Validate tag for both Git and Docker usage
           if [ -z "$TAG" ]; then
@@ -122,7 +133,11 @@ jobs:
       - name: Build & push final image
         run: |
           IMAGE="ghcr.io/${{ github.repository }}"
-          TAG="${{ inputs.tag }}"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG="${{ inputs.tag }}"
+          fi
 
           for attempt in 1 2 3; do
             echo "::group::Attempt $attempt of 3"
@@ -166,19 +181,42 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Determine tag and latest eligibility
+        id: resolve
+        run: |
+          # Resolve tag from release event or workflow_dispatch input
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+            IS_PRERELEASE="${{ github.event.release.prerelease }}"
+          else
+            TAG="${{ inputs.tag }}"
+            IS_PRERELEASE="false"
+            # Auto-detect pre-release from tag name
+            if [[ "$TAG" =~ -(pre|alpha|beta|rc) ]]; then
+              IS_PRERELEASE="true"
+            fi
+            # Allow manual override via update_latest input
+            if [ "${{ inputs.update_latest }}" = "false" ]; then
+              IS_PRERELEASE="true"
+            fi
+          fi
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "is_prerelease=${IS_PRERELEASE}" >> $GITHUB_OUTPUT
+          echo "::notice::Tag=${TAG}, Pre-release=${IS_PRERELEASE}"
+
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=${{ inputs.tag }}
-            type=raw,value=latest
+            type=raw,value=${{ steps.resolve.outputs.tag }}
+            type=raw,value=latest,enable=${{ steps.resolve.outputs.is_prerelease != 'true' }}
 
       - name: Create and push manifest
         uses: int128/docker-manifest-create-action@44422a4b046d55dc036df622039ed3aec43c613c # v2.17.0
         with:
           tags: ${{ steps.meta.outputs.tags }}
           sources: |
-            ghcr.io/${{ github.repository }}:${{ inputs.tag }}-linux-amd64
-            ghcr.io/${{ github.repository }}:${{ inputs.tag }}-linux-arm64
+            ghcr.io/${{ github.repository }}:${{ steps.resolve.outputs.tag }}-linux-amd64
+            ghcr.io/${{ github.repository }}:${{ steps.resolve.outputs.tag }}-linux-arm64

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -10,13 +10,21 @@ name: Scan terrarium image (Trivy)
 on:
   push:
     branches: [master]
+    paths:
+      - 'docker/**'
+      - '.github/workflows/scan.yaml'
   pull_request:
     branches: [master]
+    paths:
+      - 'docker/**'
+      - '.github/workflows/scan.yaml'
   # Also run after the build workflow completes (image may now be in GHCR)
   workflow_run:
     workflows: ["Build, test & publish terrarium"]
     types: [completed]
     branches: [master]
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       debug_context:
@@ -24,7 +32,7 @@ on:
         type: boolean
         default: false
   schedule:
-    - cron: "0 13 * * *"
+    - cron: "0 6 * * 1"  # Weekly Monday 06:00 UTC
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
-## [4.7.0] - 2026-03-23 — Rocky 9 tool upgrades, tfsec→Trivy, GCP CLI and Security Hardening ( PR #42 )
+## [4.8.1] - 2026-04-02 — Release workflow hardening, scan optimization, cinc-auditor update
+
+### Fixed
+
+- **`latest` tag no longer updated on pre-releases**: Release workflow now auto-detects pre-release tags (`-pre`, `-alpha`, `-beta`, `-rc`) and skips `latest` tag update. Also respects GitHub Release `prerelease` flag for event-triggered releases.
+- **Manual override for `latest` tag**: Added `update_latest` input to `workflow_dispatch` for operator control.
+- **Scan workflow trigger optimization**: Restricted `push` and `pull_request` triggers to path-filtered changes (`docker/**`, `.github/workflows/scan.yaml`). Changed schedule from daily to weekly (Monday 06:00 UTC). Added `release: [published]` trigger.
+
+### Added
+
+- `release` event trigger (`types: [published]`) on release workflow — supports GitHub Releases in addition to manual dispatch.
+
+### Upgraded
+
+- cinc-auditor-bin 5.22.55 → 5.22.95 (with inspec/inspec-core 5.22.95)
+
+---
+
+## [4.8.0] - 2026-03-23 — Rocky 9 tool upgrades, tfsec→Trivy, GCP CLI and Security Hardening ( PR #42 )
 
 ### Security
 

--- a/TOOLS_AND_LICENSES.md
+++ b/TOOLS_AND_LICENSES.md
@@ -8,6 +8,8 @@ compliance with their organization's policies.
 > For a machine-readable SBOM, see the BuildKit SBOM attestation attached to
 > published images (`--sbom=true`), or generate one locally with
 > `make sbom` (requires [Syft](https://github.com/anchore/syft)).
+>
+> Please also see the [Maintenance](#maintenance) section at the end of this file for instructions on how to keep this inventory up to date when making changes to the Dockerfile or OS packages etc.
 
 ---
 

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -15,7 +15,7 @@ end
 source 'https://rubygems.cinc.sh' do
   gem 'inspec-core'
   gem 'inspec'
-  gem 'cinc-auditor-bin', '~> 5.22', '>= 5.22.55'
+  gem 'cinc-auditor-bin', '~> 5.22', '>= 5.22.95'
   gem 'unf_ext'
   gem 'chef-config'
   gem 'chef-utils'

--- a/docker/Gemfile.lock
+++ b/docker/Gemfile.lock
@@ -10,11 +10,11 @@ GEM
       tomlrb (~> 1.2)
     chef-utils (18.5.0)
       concurrent-ruby
-    cinc-auditor-bin (5.22.55)
-      inspec (= 5.22.55)
-    inspec (5.22.55)
+    cinc-auditor-bin (5.22.95)
+      inspec (= 5.22.95)
+    inspec (5.22.95)
       faraday_middleware (>= 0.12.2, < 1.3)
-      inspec-core (= 5.22.55)
+      inspec-core (= 5.22.95)
       mongo (= 2.13.2)
       progress_bar (~> 1.3.3)
       rake
@@ -23,7 +23,7 @@ GEM
       train-habitat (~> 0.1)
       train-kubernetes (~> 0.1)
       train-winrm (~> 0.2)
-    inspec-core (5.22.55)
+    inspec-core (5.22.95)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       cookstyle
@@ -2087,7 +2087,7 @@ DEPENDENCIES
   aws-sdk (~> 3)!
   chef-config!
   chef-utils!
-  cinc-auditor-bin (~> 5.22, >= 5.22.55)!
+  cinc-auditor-bin (~> 5.22, >= 5.22.95)!
   csv!
   inspec!
   inspec-core!


### PR DESCRIPTION
## Summary

- **Conditional `latest` tag**: Pre-releases (`-pre`, `-alpha`, `-beta`, `-rc`) no longer update `latest`. Supports both `workflow_dispatch` (auto-detect from tag name) and `release` events (GitHub `prerelease` flag). Adds `update_latest` input for manual override.
- **Scan workflow optimization**: Path-filtered `push`/`pull_request` triggers (`docker/**`, `.github/workflows/scan.yaml`). Schedule changed from daily to weekly Monday 06:00 UTC. Added `release: [published]` trigger.
- **cinc-auditor-bin bump**: 5.22.55 → 5.22.95 (with inspec/inspec-core updated to match)
- **CHANGELOG updated** for v4.8.1
- **TOOLS_AND_LICENSES.md** maintenance prompt added

Addresses feedback:
- "Released version v4.8.0-pre however it was greedy and pulled the latest tag"
- "That scan workflow seems a bit greedy running on every pull request the same check"
- "I missed also to ask for cinc-auditor-bin updates"

## Test plan

- [ ] Dispatch release with a pre-release tag (e.g. `v4.8.1-pre`) — verify `latest` is NOT updated
- [ ] Dispatch release with a stable tag (e.g. `v4.8.1`) — verify `latest` IS updated
- [ ] Dispatch release with `update_latest=false` — verify `latest` is NOT updated
- [ ] Create a GitHub Release marked as pre-release — verify `latest` is NOT updated
- [ ] Push a non-Docker change to master — verify scan workflow does NOT trigger
- [ ] Push a Docker change to master — verify scan workflow DOES trigger
- [ ] Verify cinc-auditor version resolves correctly during image build
